### PR TITLE
Fix multi-handle People flow progression

### DIFF
--- a/1.4_0/pages/popup.html
+++ b/1.4_0/pages/popup.html
@@ -38,8 +38,12 @@
                 <div class="inputs-by-row">
                     <section class="input-group">
                         <label for="keywordInput">🔍 Enter Search Keyword:</label>
-                        <input type="text" id="keywordInput" placeholder="Enter keyword..."
-                            aria-label="Search keyword input" />
+                        <textarea id="keywordInput" placeholder="Enter keyword..." rows="1"
+                            aria-label="Search keyword input"></textarea>
+                        <p class="input-helper" id="peopleHandlesHint" style="display: none;">
+                            Tip: Add multiple usernames separated by commas or new lines (e.g. <code>@firstuser</code>,
+                            <code>seconduser</code>).
+                        </p>
                     </section>
                     <section class="input-group">
                         <label for="searchType">🎯 Keyword Search Type:</label>

--- a/1.4_0/scripts/content/homeContent.js
+++ b/1.4_0/scripts/content/homeContent.js
@@ -8,6 +8,14 @@ var minVal;
 var maxVal;
 var mediaFilePath;
 var mediaType;
+var keyword;
+var keywordList = [];
+var peopleHandles = [];
+var postsPerHandle = 1;
+var totalTaskCount = 0;
+var lastHandleIndex = -1;
+var normalizedProfileHandle = null;
+var targetedProfileReady = false;
 var likeStatus = null;
 var commentStatus = null;
 var repostStatus = null;
@@ -36,7 +44,7 @@ async function waitForResume() {
     }
 }
 
-chrome.storage.local.get(["keyword", "options", "numberofpost", "commentText", "searchType", 'maxVal','minVal', 'mediaFilePath', 'mediaType', 'isPaused', 'postIndex', 'postResult'], async (result) => {
+chrome.storage.local.get(["keyword", "primaryKeyword", "keywordList", "options", "numberofpost", "commentText", "searchType", 'maxVal','minVal', 'mediaFilePath', 'mediaType', 'isPaused', 'postIndex', 'postResult', 'totalTaskCount'], async (result) => {
     console.log("Retrieved Data:", result);
     console.log("ispaused", result.isPaused);
     isPaused = result.isPaused;
@@ -57,12 +65,56 @@ chrome.storage.local.get(["keyword", "options", "numberofpost", "commentText", "
     }
     minVal = result.minVal;
     maxVal = result.maxVal;
-    total_comment = result.numberofpost;
+    let storedPosts = parseInt(result.numberofpost, 10);
+    postsPerHandle = !isNaN(storedPosts) && storedPosts > 0 ? storedPosts : 1;
     action = result.options;
     comment = result.commentText;
     searchType = result.searchType;
     mediaFilePath = result.mediaFilePath
     mediaType = result.mediaType
+    keyword = result.primaryKeyword || result.keyword;
+    keywordList = Array.isArray(result.keywordList) ? result.keywordList.map(handle => normalizeHandle(handle)).filter(Boolean) : [];
+    peopleHandles = keywordList.length ? [...keywordList] : [];
+    if (peopleHandles.length > 1) {
+        const seenHandles = new Set();
+        peopleHandles = peopleHandles.filter(handle => {
+            const key = handle.toLowerCase();
+            if (seenHandles.has(key)) {
+                return false;
+            }
+            seenHandles.add(key);
+            return true;
+        });
+    }
+    if (searchType === "people" && peopleHandles.length === 0 && keyword) {
+        const fallbackHandle = normalizeHandle(keyword);
+        if (fallbackHandle) {
+            peopleHandles = [fallbackHandle];
+        }
+    }
+    const storedTotal = parseInt(result.totalTaskCount, 10);
+    if (searchType === "people") {
+        const computedTotal = postsPerHandle * (peopleHandles.length > 0 ? peopleHandles.length : 1);
+        totalTaskCount = !isNaN(storedTotal) && storedTotal > 0 ? storedTotal : computedTotal;
+        if (peopleHandles.length > 0) {
+            normalizedProfileHandle = peopleHandles[0];
+        } else {
+            normalizedProfileHandle = normalizeHandle(keyword);
+        }
+        if (isNaN(storedTotal) || storedTotal !== totalTaskCount) {
+            chrome.storage.local.set({ totalTaskCount });
+        }
+    } else {
+        totalTaskCount = !isNaN(storedTotal) && storedTotal > 0 ? storedTotal : postsPerHandle;
+        normalizedProfileHandle = normalizeHandle(keyword);
+        if (isNaN(storedTotal) || storedTotal !== totalTaskCount) {
+            chrome.storage.local.set({ totalTaskCount });
+        }
+        peopleHandles = [];
+    }
+    total_comment = totalTaskCount;
+    targetedProfileReady = false;
+    lastHandleIndex = -1;
     console.log("🔎 Search Type:", searchType);
     console.log("🔎 Search Type:", result.commentText);
     console.log("mediaFilePath:", result.mediaFilePath);
@@ -84,9 +136,27 @@ chrome.storage.local.get(["keyword", "options", "numberofpost", "commentText", "
         else {
             console.log(`Running task ${index + 1}...`);
             await sleep(1)
-            await indexupdate(index)
             console.log("not breck");
             console.log("index``````````````````", index);
+            postDetails = "";
+            likeStatus = null;
+            commentStatus = null;
+            repostStatus = null;
+            if (searchType === "people") {
+                if (peopleHandles.length > 0) {
+                    const handleIndex = Math.floor(index / postsPerHandle);
+                    const boundedIndex = Math.min(handleIndex, peopleHandles.length - 1);
+                    const nextHandle = peopleHandles[boundedIndex];
+                    if (boundedIndex !== lastHandleIndex || normalizedProfileHandle !== nextHandle) {
+                        lastHandleIndex = boundedIndex;
+                        normalizedProfileHandle = nextHandle;
+                        targetedProfileReady = false;
+                        console.log(`🎯 Switching to profile @${normalizedProfileHandle} (${boundedIndex + 1}/${peopleHandles.length})`);
+                    }
+                } else {
+                    normalizedProfileHandle = normalizeHandle(keyword);
+                }
+            }
             if (searchType == "latest") {
                 console.log("🔍 Executing Latest Search");
                 await latest();
@@ -98,12 +168,25 @@ chrome.storage.local.get(["keyword", "options", "numberofpost", "commentText", "
                 await media();
             } else if (searchType == "people") {
                 console.log("🔍 Executing People Search");
-                await people();
+                const handled = await people();
+                if (!handled) {
+                    console.warn("⚠️ No tweet processed for this task, marking as skipped.");
+                    await indexupdate(index + 1);
+                    sendStatusToBackground(false, "No eligible tweet found", likeStatus, commentStatus, repostStatus, postResult);
+                    continue;
+                }
             } else {
                 console.log("not provide valid input");
             }
+            if (!postDetails) {
+                console.warn("Post details missing after processing; skipping result recording.");
+                await indexupdate(index + 1);
+                sendStatusToBackground(false, "Post details missing", likeStatus, commentStatus, repostStatus, postResult);
+                continue;
+            }
             let parts = postDetails.split("/status/");
             postResult.push({ username: parts[0], tweetId: parts[1], likeStatus: likeStatus, commentStatus: commentStatus, repostStatus: repostStatus, });
+            await indexupdate(index + 1);
             sendStatusToBackground(true, "Repost successful", likeStatus, commentStatus, repostStatus, postResult);
           let  staticInteval = await getRandomNumber(minVal, maxVal)
           console.log("staticInteval",staticInteval);
@@ -123,16 +206,16 @@ async function getRandomNumber(min, max) {
 }
 
 
-async function indexupdate(index) {
+async function indexupdate(nextIndex) {
     return new Promise((resolve, reject) => {
-        chrome.storage.local.set({ postIndex: index + 1 }, () => {
-            console.log("🔄 Updated postIndex to:", index);
+        chrome.storage.local.set({ postIndex: nextIndex }, () => {
+            console.log("🔄 Updated postIndex to:", nextIndex);
             resolve();
         });
     });
 }
 function sendStatusToBackground(status, message, likeStatus, commentStatus, repostStatus) {
-    chrome.storage.local.get(["progressData", "postIndex", "numberofpost"], (data) => {
+    chrome.storage.local.get(["progressData", "postIndex", "numberofpost", "totalTaskCount"], (data) => {
         let progressData = data.progressData || {
             likeSent: "0",
             likeFailed: "0",
@@ -144,7 +227,11 @@ function sendStatusToBackground(status, message, likeStatus, commentStatus, repo
         };
 
         let postIndex = data.postIndex || 0;
-        let totalPosts = data.numberofpost || 0;
+        let totalPosts = data.totalTaskCount ?? data.numberofpost ?? 0;
+        totalPosts = parseInt(totalPosts, 10);
+        if (isNaN(totalPosts) || totalPosts < 0) {
+            totalPosts = 0;
+        }
 
         if (likeStatus !== null) {
             progressData[likeStatus ? "likeSent" : "likeFailed"] = (parseInt(progressData[likeStatus ? "likeSent" : "likeFailed"]) + 1).toString();
@@ -413,9 +500,18 @@ async function likeclick() {
 }
 async function backButtonClick() {
     try {
-        document.querySelector("div.css-175oi2r.r-1pz39u2.r-1777fci.r-15ysp7h.r-1habvwh.r-s8bhmr > button > div").click();
+        let backButton = document.querySelector('button[data-testid="app-bar-back"]');
+        if (!backButton) {
+            backButton = document.querySelector("div.css-175oi2r.r-1pz39u2.r-1777fci.r-15ysp7h.r-1habvwh.r-s8bhmr > button > div");
+        }
+        if (backButton) {
+            backButton.click();
+        } else {
+            window.history.back();
+        }
     } catch (error) {
-        console.log("backButtonClick Error", error)
+        console.log("backButtonClick Error", error);
+        window.history.back();
     }
 }
 
@@ -467,7 +563,7 @@ async function getLastQueryParam() {
         return null;
     }
 }
-async function people() {
+async function legacyPeopleFlow() {
     let result = false;
     if (attempt == undefined) {
         attempt = 1;
@@ -492,12 +588,18 @@ async function people() {
 
         await sleep(2)
     }
-    while (!result) {
+    let safetyCounter = 0;
+    while (!result && safetyCounter < 10) {
+        safetyCounter++;
         await sleep(2)
         console.log("Click people button");
         let peopleclick = document.querySelector(`#react-root > div > div > div.css-175oi2r.r-1f2l425.r-13qz1uu.r-417010.r-18u37iz > main > div > div > div > div.css-175oi2r.r-kemksi.r-1kqtdi0.r-1ua6aaf.r-th6na.r-1phboty.r-16y2uox.r-184en5c.r-1abdc3e.r-1lg4w6u.r-f8sm7e.r-13qz1uu.r-1ye8kvj > div > div:nth-child(3) > section > div > div > div:nth-child(${attempt}) > div > div > button > div > div.css-175oi2r.r-1iusvr4.r-16y2uox > div.css-175oi2r.r-1awozwy.r-18u37iz.r-1wtj0ep`)
 
         await sleep(1)
+        if (!peopleclick) {
+            console.warn("Unable to locate a profile entry in People search results.");
+            break;
+        }
         await peopleclick.click()
         await sleep(1)
         window.scrollBy({
@@ -579,6 +681,25 @@ async function people() {
         left: 0,
         behavior: "smooth"
     });
+    return result;
+}
+
+async function people() {
+    if (normalizedProfileHandle) {
+        const handled = await targetedPeopleFlow();
+        if (handled) {
+            return true;
+        }
+        if (window.location.pathname.startsWith('/search')) {
+            console.warn("Targeted profile failed, falling back to legacy people search flow.");
+            normalizedProfileHandle = null;
+            targetedProfileReady = false;
+        } else {
+            console.warn("Targeted profile flow could not process a tweet and fallback is not applicable on this page.");
+            return false;
+        }
+    }
+    return await legacyPeopleFlow();
 }
 
 async function media() {
@@ -699,9 +820,6 @@ async function waitForElement(selector, timeout = 20000) {
     });
 }
 
-async function sleep(seconds) {
-    return new Promise(resolve => setTimeout(resolve, seconds * 1000));
-}
 async function waitForVideoProcessingCompletion(timeout = 180000, interval = 3000) {
     return new Promise((resolve, reject) => {
         const startTime = Date.now();
@@ -758,6 +876,166 @@ async function uploadMediaFromLocalPath(base64String, mediaType) {
         console.log(`✅ ${mediaType} is fully processed and ready!`);
     } catch (error) {
         console.log(` Error uploading ${mediaType}:`, error);
+    }
+}
+
+function normalizeHandle(value) {
+    if (!value) {
+        return null;
+    }
+    let cleaned = value.trim();
+    cleaned = cleaned.replace(/^https?:\/\/(www\.)?(twitter|x)\.com\//i, "");
+    cleaned = cleaned.replace(/^@/, "");
+    cleaned = cleaned.split(/[/?\s]/)[0];
+    return cleaned ? cleaned : null;
+}
+
+function isOnTargetProfilePage() {
+    if (!normalizedProfileHandle) {
+        return false;
+    }
+    const currentPath = window.location.pathname.toLowerCase();
+    const handlePath = `/${normalizedProfileHandle.toLowerCase()}`;
+    return currentPath === handlePath || currentPath.startsWith(`${handlePath}/`);
+}
+
+async function targetedPeopleFlow() {
+    try {
+        const ready = await ensureTargetProfileReady();
+        if (!ready) {
+            console.warn("Target profile could not be prepared.");
+            return false;
+        }
+        const anchor = await findNextTweetOnProfile();
+        if (!anchor) {
+            console.warn("No new tweets found on target profile.");
+            return false;
+        }
+        const timeElement = anchor.querySelector('time');
+        if (timeElement) {
+            timeElement.click();
+        } else {
+            anchor.click();
+        }
+        await sleep(2);
+        await postclick();
+        await safelyReturnToProfileTimeline();
+        return true;
+    } catch (error) {
+        console.error("Error during targeted people flow:", error);
+        return false;
+    }
+}
+
+async function ensureTargetProfileReady() {
+    if (!normalizedProfileHandle) {
+        return false;
+    }
+    if (targetedProfileReady && isOnTargetProfilePage()) {
+        return true;
+    }
+    if (isOnTargetProfilePage()) {
+        targetedProfileReady = true;
+        return true;
+    }
+    const path = window.location.pathname;
+    if (path.startsWith(`/search`)) {
+        await selectPeopleTab();
+        const profileLink = await findProfileLinkForHandle(normalizedProfileHandle);
+        if (!profileLink) {
+            console.warn("Unable to locate target profile in People results.");
+            return false;
+        }
+        profileLink.click();
+        const navigated = await waitForCondition(() => isOnTargetProfilePage(), 12000, 300);
+        targetedProfileReady = navigated;
+        return navigated;
+    }
+    const targetUrl = `https://x.com/${normalizedProfileHandle}`;
+    const targetPath = `/${normalizedProfileHandle.toLowerCase()}`;
+    if (window.location.pathname.toLowerCase() !== targetPath) {
+        window.location.href = targetUrl;
+    }
+    const navigated = await waitForCondition(() => isOnTargetProfilePage(), 15000, 300);
+    targetedProfileReady = navigated;
+    return navigated;
+}
+
+async function selectPeopleTab() {
+    const currentTab = await getLastQueryParam();
+    if (currentTab === "user") {
+        return;
+    }
+    const tabLinks = Array.from(document.querySelectorAll('a[role="tab"], div[role="tab"] > a'));
+    const peopleTab = tabLinks.find(link => link.textContent.trim().toLowerCase() === "people");
+    if (peopleTab) {
+        peopleTab.click();
+        await sleep(2);
+    }
+}
+
+async function findProfileLinkForHandle(handle, maxScrollAttempts = 6) {
+    const targetPath = `/${handle.toLowerCase()}`;
+    for (let attemptIndex = 0; attemptIndex < maxScrollAttempts; attemptIndex++) {
+        const links = Array.from(document.querySelectorAll('a[href^="/"]'));
+        const match = links.find(link => {
+            const href = (link.getAttribute('href') || '').toLowerCase().split('?')[0].replace(/\/+$/, '');
+            if (href !== targetPath) {
+                return false;
+            }
+            const text = (link.textContent || '').toLowerCase();
+            return text.includes(`@${handle.toLowerCase()}`) || link.getAttribute('role') === 'link';
+        });
+        if (match) {
+            return match;
+        }
+        window.scrollBy({ top: 600, left: 0, behavior: "smooth" });
+        await sleep(1.5);
+    }
+    return null;
+}
+
+async function waitForCondition(conditionFn, timeoutMs = 10000, intervalMs = 250) {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        try {
+            if (conditionFn()) {
+                return true;
+            }
+        } catch (error) {
+            console.warn("waitForCondition check error:", error);
+        }
+        await new Promise(resolve => setTimeout(resolve, intervalMs));
+    }
+    return false;
+}
+
+async function findNextTweetOnProfile(maxScrollAttempts = 6) {
+    for (let attemptIndex = 0; attemptIndex < maxScrollAttempts; attemptIndex++) {
+        const anchors = Array.from(document.querySelectorAll('article a[href*="/status/"]')).filter(anchor => anchor.querySelector('time'));
+        for (const anchor of anchors) {
+            const href = anchor.getAttribute('href');
+            if (!href) {
+                continue;
+            }
+            const url = `https://x.com${href}`;
+            const isNew = await checkAndStoreUrl(url);
+            if (isNew) {
+                return anchor;
+            }
+        }
+        window.scrollBy({ top: 800, left: 0, behavior: "smooth" });
+        await sleep(2);
+    }
+    return null;
+}
+
+async function safelyReturnToProfileTimeline() {
+    await sleep(1);
+    await backButtonClick();
+    await sleep(2);
+    if (normalizedProfileHandle && !isOnTargetProfilePage()) {
+        await waitForCondition(() => isOnTargetProfilePage(), 8000, 300);
     }
 }
 

--- a/1.4_0/styles/styles.css
+++ b/1.4_0/styles/styles.css
@@ -71,6 +71,19 @@ h2 {
   color: #444;
 }
 
+.input-helper {
+  margin-top: 6px;
+  font-size: 12px;
+  color: #555;
+  line-height: 1.4;
+}
+
+.input-helper code {
+  background: #f3f4f6;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
 .input-group input,
 .input-group select,
 .input-group textarea {

--- a/analysis/download-guide.md
+++ b/analysis/download-guide.md
@@ -1,0 +1,48 @@
+# Download the Extension the Easy Way
+
+Want the latest extension without wrestling with Git? Follow the short version below, then keep reading if you need the details.
+
+## Super-quick summary
+1. **Open the terminal pane.** It lives at the bottom of the workspace.
+2. **Run one command:** `./package_extension.sh`
+3. **Download the ZIP** (`extension-1.4_0.zip`) from the file tree and unzip it on your computer.
+
+That’s it—you now have the extension folder (`1.4_0/`) ready for `chrome://extensions` → **Developer mode** → **Load unpacked**.
+
+---
+
+## Step 1 – Open the terminal pane (with pictures in mind)
+If you don’t already see a terminal:
+
+1. Look along the bottom edge of the workspace for a panel named **Terminal** or **Console**.
+2. If the panel is collapsed, click the **Terminal** tab or the little `>` chevron to pop it open.
+3. Press the **+** button inside that panel and choose **New Terminal**. When you see a line ending in `$` or `#`, you’re ready to type commands.
+
+Leave this terminal window open for the rest of the steps.
+
+## Step 2 – Let the script zip everything for you
+1. In the terminal, make sure you are already inside the project folder (the prompt should show `/workspace/Twi`).
+2. Type the command below and press **Enter**:
+   ```bash
+   ./package_extension.sh
+   ```
+3. Wait a moment—when the script finishes you’ll see the message `Created extension-1.4_0.zip`.
+
+## Step 3 – Download the ZIP to your computer
+1. In the file browser (usually on the left), find `extension-1.4_0.zip` sitting next to `package_extension.sh`.
+2. Right-click the ZIP and choose **Download** (or click the download icon your IDE provides).
+3. Once the ZIP is on your computer, unzip it. Inside you’ll see the familiar `1.4_0/` extension folder.
+4. Load that folder in Chrome via `chrome://extensions` → enable **Developer mode** → **Load unpacked** → pick the `1.4_0/` folder.
+
+---
+
+## Alternative options (use these only if you want them)
+- **Manual zip command:**
+  ```bash
+  zip -r extension-1.4_0.zip 1.4_0
+  ```
+  This does exactly what the script does, just without the shortcut.
+
+- **Download from GitHub:** Push your commits, open the repo on GitHub, click **Code → Download ZIP**, and unzip it locally.
+
+> **Need a refresh later?** Run `./package_extension.sh` again. It will overwrite the old ZIP with a brand-new package.

--- a/analysis/extension-review.md
+++ b/analysis/extension-review.md
@@ -1,0 +1,44 @@
+# Twitter Automation Extension Review
+
+## Overview
+- The extension brands itself as "Twitter Automation" and declares automation of tweets, likes, and comments directly in the manifest.【F:1.4_0/manifest.json†L1-L27】
+- A background service worker coordinates navigation to x.com, injects different content scripts for search, recycling tweets, and targeting specific accounts, and persists settings/results in `chrome.storage.local`.【F:1.4_0/scripts/background.js†L17-L294】
+- Popup pages collect user input (keywords, actions, intervals, media uploads) and send commands to the background worker while also rendering progress dashboards fed by storage updates.【F:1.4_0/pages/popup.html†L1-L118】【F:1.4_0/scripts/popup.js†L200-L517】
+
+## Key Behaviors
+- Content scripts drive the automation loop: `homeContent.js` iterates over search results and performs like/repost/comment actions, while tracking progress and avoiding duplicates by storing visited tweet URLs.【F:1.4_0/scripts/content/homeContent.js†L1-L171】【F:1.4_0/scripts/content/homeContent.js†L365-L457】
+- Media attachments are supported by converting local files to base64 in the popup, storing them in extension storage, and recreating `File` objects in the content script before posting replies.【F:1.4_0/scripts/popup.js†L393-L446】【F:1.4_0/scripts/content/homeContent.js†L640-L718】
+- The recycle workflow optionally collects a Gemini API key and prompt that are also persisted to `chrome.storage.local`, then injects `recyclePost.js` with the extracted tweet ID.【F:1.4_0/scripts/recycle.js†L160-L207】
+
+## Security & Privacy Concerns
+1. **Broad host permissions** – Granting access to all `file://*` URLs alongside every subdomain on x.com is excessive; a compromised extension could read any local file the user selects in a file picker.【F:1.4_0/manifest.json†L15-L27】
+2. **Sensitive data at rest** – Gemini API keys and custom prompts are stored in plain text in `chrome.storage.local`, which is readable by any code in the extension and by other extensions with debugging access.【F:1.4_0/scripts/recycle.js†L160-L207】
+3. **User media persistence** – Uploaded images/videos are converted to base64 strings and persisted in `chrome.storage.local`, significantly expanding the attack surface and risking quota exhaustion for large media files.【F:1.4_0/scripts/popup.js†L393-L446】【F:1.4_0/scripts/background.js†L19-L70】
+4. **Unbounded history growth** – The automation history (`storedUrls`) grows monotonically with every processed tweet and is never trimmed, which can leak long-term interaction history and consume storage unnecessarily.【F:1.4_0/scripts/content/homeContent.js†L431-L457】
+
+## Reliability & Maintenance Issues
+- **Pause/Resume logic is inverted and incomplete** – `waitForResume` treats `isPaused === false` as the stop condition, so toggling the pause button actually sets `isPaused` to `false` and breaks the main loop; the background worker never handles the `pauseProcess`/`loadContentScript` messages that the popup sends.【F:1.4_0/scripts/content/homeContent.js†L22-L116】【F:1.4_0/scripts/popup.js†L200-L225】【F:1.4_0/scripts/background.js†L17-L294】
+- **Duplicate helpers with divergent behavior** – Two separate `waitForElement` implementations exist in `homeContent.js` with different defaults, inviting confusion about which one a caller will invoke depending on hoisting order.【F:1.4_0/scripts/content/homeContent.js†L181-L214】【F:1.4_0/scripts/content/homeContent.js†L685-L704】
+- **Extremely brittle selectors** – The automation depends on deeply nested, minified CSS class chains (e.g., `.css-175oi2r.r-18u37iz.r-1q142lx > a`), so even minor DOM changes on X.com will break the workflow; error handling typically just logs and retries without fallback.【F:1.4_0/scripts/content/homeContent.js†L185-L214】【F:1.4_0/scripts/content/homeContent.js†L365-L418】
+- **Background message fan-out** – The service worker broadcasts storage updates to the popup without verifying listener availability, leading to frequent rejected promise warnings already acknowledged in comments.【F:1.4_0/scripts/background.js†L168-L294】
+
+## Compliance & Platform Risks
+- Automating likes, reposts, and comments at scale is almost certainly against X/Twitter's terms of service and automation policies, putting user accounts at risk of suspension. The code explicitly loops through search results performing these actions without user intervention.【F:1.4_0/scripts/content/homeContent.js†L75-L171】【F:1.4_0/scripts/content/homeContent.js†L365-L418】
+
+## Recommendations
+1. Minimize permissions (drop `file://*`, scope host access, and gate Gemini requests behind explicit user consent).
+2. Avoid persisting raw API keys or media data; use scoped session storage and clear sensitive entries immediately after use.
+3. Refactor pause/resume to use clear state names (`isRunning`), handle `pauseProcess` in the service worker, and remove dead `loadContentScript` messaging.
+4. Consolidate helper utilities (single `waitForElement`, shared `sleep`) and replace fragile selectors with resilient `data-testid` targets and guard clauses.
+5. Implement retention policies for `storedUrls` and progress logs so storage cannot grow unbounded.
+6. Reassess the ethical/compliance implications of automating engagement actions before distributing the extension publicly.
+
+## Feature Improvement Opportunities
+- **Campaign templates & presets** – Provide reusable recipes (e.g., product launch, community engagement) that prefill search queries, action cadence, and content prompts so users can start quickly while staying within safe interaction limits.
+- **Adaptive pacing** – Instrument rate limiting that reacts to API/DOM error signals or account warnings, automatically slowing or pausing automation to reduce the risk of triggering platform enforcement.
+- **Human-in-the-loop drafts** – Offer an optional approval queue where generated replies are staged for manual review before posting, combining automation efficiency with content quality control.
+- **Insight dashboard** – Summarize impressions, engagement counts, and follow-back metrics collected after each run, helping users understand impact and tune future campaigns.
+- **Account & list targeting** – Allow importing curated lists of accounts or communities and rotate through them intelligently, rather than relying solely on keyword searches.
+- **Safety guardrails** – Detect sensitive topics or potentially harmful language via lightweight moderation models, warning the user or skipping problematic posts to protect brand reputation.
+- **Onboarding checklist** – Incorporate contextual tooltips and walkthroughs in the popup UI that highlight best practices, compliance reminders, and how to configure each workflow.
+

--- a/package_extension.sh
+++ b/package_extension.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTPUT_NAME="extension-1.4_0.zip"
+SOURCE_DIR="1.4_0"
+
+cd "$ROOT_DIR"
+
+if [ ! -d "$SOURCE_DIR" ]; then
+  echo "Source directory '$SOURCE_DIR' not found." >&2
+  exit 1
+fi
+
+zip -r "$OUTPUT_NAME" "$SOURCE_DIR" > /dev/null
+
+echo "Created $OUTPUT_NAME in $ROOT_DIR" 


### PR DESCRIPTION
## Summary
- defer post index updates until after a tweet is processed so multi-handle runs resume the correct profile
- reset task state and handle skipped tweets without duplicating prior results before saving progress
- harden the legacy People fallback with guards and explicit return values to avoid stalling on profile pages

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68e4e05f07a4832bb6f9ab4eda14ad9c